### PR TITLE
disabled curl output buffering for grep check

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -649,7 +649,7 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME MY_PORT || [[ -n "$MY_COMMAND" ]]; 
 		fi
 	elif [[ "$MY_COMMAND" = "grep" ]]; then
 		let MY_HOSTNAME_COUNT++
-		if curl -fs --max-time "$MY_TIMEOUT" "$MY_HOSTNAME" | grep -q "$MY_PORT"  &> /dev/null; then
+		if curl --no-buffer -fs --max-time "$MY_TIMEOUT" "$MY_HOSTNAME" | grep -q "$MY_PORT"  &> /dev/null; then
 			check_downtime "$MY_COMMAND" "$MY_HOSTNAME" "$MY_PORT"
 			# Check status change
 			if [[ "$MY_DOWN_TIME" -gt "0" ]]; then


### PR DESCRIPTION
Hey there,

the curl check sometimes resulted in an "(23) Failed writing body" Error. It occurs when the pipe curl is writing to gets closed. Disabling the write buffer in curl should prevent this.

from "man curl": DN: -N, --no-buffer: Disables  the  buffering  of the output stream.
In normal work situations, curl will use a standard buffered output stream that
will have the effect that it will output the data in chunks, not necessarily
exactly when the data arrives.  Using this option will disable that buffering.

This way, grep is not closing the pipe while curl stil has chunks left - which
results in a "(23) Failed writing body" error.

cheers
Alex