### PR TITLE
A bunch of minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ status_hostname_ok.txt
 *.html
 *.gif
 *.jpg
-
+config

--- a/config-example
+++ b/config-example
@@ -1,0 +1,43 @@
+################################################################################
+#### Configuration Section
+################################################################################
+
+# Title for the status page
+MY_STATUS_TITLE="Status Page"
+
+# Link for the homepage button
+MY_HOMEPAGE_URL="https://github.com/Cyclenerd/static_status"
+
+# Shortcut to place the configuration file in a folder.
+# Save it without / at the end.
+MY_STATUS_CONFIG_DIR="$HOME/status"
+
+# List with the configuration. What do we want to monitor?
+MY_HOSTNAME_FILE="$MY_STATUS_CONFIG_DIR/status_hostname_list.txt"
+
+# Where should the HTML status page be stored?
+MY_STATUS_HTML="$HOME/status_index.html"
+
+# Text file in which you can place a status message.
+# If the file exists and has a content, all errors on the status page are overwritten.
+MY_MAINTENANCE_TEXT_FILE="$MY_STATUS_CONFIG_DIR/status_maintenance_text.txt"
+
+# Duration we wait for response (nc and curl).
+MY_TIMEOUT="2"
+
+# Location for the status files. Please do not edit created files.
+MY_HOSTNAME_STATUS_OK="$MY_STATUS_CONFIG_DIR/status_hostname_ok.txt"
+MY_HOSTNAME_STATUS_DOWN="$MY_STATUS_CONFIG_DIR/status_hostname_down.txt"
+MY_HOSTNAME_STATUS_LASTRUN="$MY_STATUS_CONFIG_DIR/status_hostname_last.txt"
+MY_HOSTNAME_STATUS_HISTORY="$MY_STATUS_CONFIG_DIR/status_hostname_history.txt"
+MY_HOSTNAME_STATUS_HISTORY_TEMP_SORT="/tmp/status_hostname_history_sort.txt"
+
+# CSS Stylesheet for the status page
+MY_STATUS_STYLESHEET="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css"
+# A footer
+MY_STATUS_FOOTER='Powered by <a href="https://github.com/Cyclenerd/static_status">static_status</a>'
+
+# Lock file to prevent duplicate execution.
+# If this file exists, status.sh script is terminated.
+# If something has gone wrong and the file has not been deleted automatically, you can delete it.
+MY_STATUS_LOCKFILE="/tmp/STATUS_SH_IS_RUNNING.lock"


### PR DESCRIPTION
Hi,

like teased in my last pr here is my first batch of changes. Since I did not want to change options within status.sh I have implemented a separate config file. Additionally I have done smaller bits of cleanup in cleaning up some unnecessary whitespace and removing service names that are already listed in /etc/services.

remove some unnecessary whitespace
externalise configuration options and add an example configuration file
ignore default configuration file in git
remove service entries that are already defined in /etc/services
extend options parser to print help if called with an unknown option (while still allow to be called without an option)
also check the existance of status_hostname_list.txt when run