### PR TITLE
Remove script from commands to check

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -88,7 +88,6 @@ MY_COMMANDS=(
 	curl
 	grep
 	traceroute
-	script
 )
 
 # if a config file has been specified with MY_STATUS_CONFIG=myfile use this one, otherwise default to config


### PR DESCRIPTION
In this case "script" is not a command-line tool but a place holder for
any other script. So there is no need to test for the tool "script"
which is also a command-line tool, available on many but not all Linux
distributions.