### PR TITLE
Command to check HTTP status code returned by an URL

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -303,6 +303,7 @@ function check_downtime() {
 		   [[ "$MY_DOWN_COMMAND" = "grep" ]] ||
 		   [[ "$MY_DOWN_COMMAND" = "traceroute" ]] ||
 		   [[ "$MY_DOWN_COMMAND" = "curl" ]] ||
+		   [[ "$MY_DOWN_COMMAND" = "http-status" ]] ||
 		   [[ "$MY_DOWN_COMMAND" = "script" ]]; then
 			if 	[[ "$MY_DOWN_HOSTNAME" = "$MY_HOSTNAME" ]]; then
 				if 	[[ "$MY_DOWN_PORT" = "$MY_PORT" ]]; then
@@ -329,6 +330,9 @@ function save_downtime() {
 		if [[ $MY_COMMAND == "grep" ]]; then
 			printf " %s" "$MY_PORT"
 		fi
+		if [[ $MY_COMMAND == "http-status" ]]; then
+			printf " %s" "$MY_PORT"
+		fi
 	fi
 }
 
@@ -344,6 +348,9 @@ function save_availability() {
 			printf " %s" "$(port_to_name "$MY_PORT")"
 		fi
 		if [[ $MY_COMMAND == "grep" ]]; then
+			printf " %s" "$MY_PORT"
+		fi
+		if [[ $MY_COMMAND == "http-status" ]]; then
 			printf " %s" "$MY_PORT"
 		fi
 	fi
@@ -370,6 +377,9 @@ function save_history() {
 			printf " %s" "$(port_to_name "$MY_PORT")"
 		fi
 		if [[ $MY_COMMAND == "grep" ]]; then
+			printf " %s" "$MY_PORT"
+		fi
+		if [[ $MY_COMMAND == "http-status" ]]; then
 			printf " %s" "$MY_PORT"
 		fi
 	fi
@@ -496,6 +506,8 @@ function item_ok() {
 			echo "$(port_to_name "$MY_OK_PORT") on $MY_OK_HOSTNAME"
 		elif [[ "$MY_OK_COMMAND" = "curl" ]]; then
 			echo "Site $MY_OK_HOSTNAME"
+		elif [[ "$MY_OK_COMMAND" = "http-status" ]]; then
+			echo "HTTP status $MY_OK_PORT of $MY_OK_HOSTNAME"
 		elif [[ "$MY_OK_COMMAND" = "grep" ]]; then
 			echo "Grep for \"$MY_OK_PORT\" on  $MY_OK_HOSTNAME"
 		elif [[ "$MY_OK_COMMAND" = "traceroute" ]]; then
@@ -523,6 +535,8 @@ function item_down() {
 			echo "$(port_to_name "$MY_DOWN_PORT") on $MY_DOWN_HOSTNAME"
 		elif [[ "$MY_DOWN_COMMAND" = "curl" ]]; then
 			echo "Site $MY_DOWN_HOSTNAME"
+		elif [[ "$MY_DOWN_COMMAND" = "http-status" ]]; then
+			echo "HTTP status $MY_DOWN_PORT of $MY_DOWN_HOSTNAME"
 		elif [[ "$MY_DOWN_COMMAND" = "grep" ]]; then
 			echo "Grep for \"$MY_DOWN_PORT\" on  $MY_DOWN_HOSTNAME"
 		elif [[ "$MY_DOWN_COMMAND" = "traceroute" ]]; then
@@ -554,6 +568,8 @@ function item_history() {
 			echo "$(port_to_name "$MY_HISTORY_PORT") on $MY_HISTORY_HOSTNAME"
 		elif [[ "$MY_HISTORY_COMMAND" = "curl" ]]; then
 			echo "Site $MY_HISTORY_HOSTNAME"
+		elif [[ "$MY_HISTORY_COMMAND" = "http-status" ]]; then
+			echo "HTTP status $MY_HISTORY_PORT of $MY_HISTORY_HOSTNAME"
 		elif [[ "$MY_HISTORY_COMMAND" = "grep" ]]; then
 			echo "Grep for \"$MY_HISTORY_PORT\" on  $MY_HISTORY_HOSTNAME"
 		elif [[ "$MY_HISTORY_COMMAND" = "traceroute" ]]; then
@@ -698,6 +714,19 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 			check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" ""
 			save_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "" "$MY_DOWN_TIME"
 		fi
+	elif [[ "$MY_COMMAND" = "http-status" ]]; then
+		(( MY_HOSTNAME_COUNT++))
+		if [[ $(curl -s -o /dev/null -I -w "%{http_code}" "$MY_HOSTNAME" 2>/dev/null) == $MY_PORT ]]; then
+			check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"
+			# Check status change
+			if [[ "$MY_DOWN_TIME" -gt "0" ]]; then
+				save_history  "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT" "$MY_DOWN_TIME" "$MY_DATE_TIME"
+			fi
+			save_availability "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"
+		else
+			check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"
+			save_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT" "$MY_DOWN_TIME"
+		fi
 	elif [[ "$MY_COMMAND" = "grep" ]]; then
 		(( MY_HOSTNAME_COUNT++ ))
 		if curl --no-buffer -fs --max-time "$MY_TIMEOUT" "$MY_HOSTNAME" | grep -q "$MY_PORT"  &> /dev/null; then
@@ -764,6 +793,7 @@ while IFS=';' read -r MY_DOWN_COMMAND MY_DOWN_HOSTNAME_STRING MY_DOWN_PORT MY_DO
 	if [[ "$MY_DOWN_COMMAND" = "ping" ]] ||
 	   [[ "$MY_DOWN_COMMAND" = "nc" ]] ||
 	   [[ "$MY_DOWN_COMMAND" = "curl" ]] ||
+	   [[ "$MY_DOWN_COMMAND" = "http-status" ]] ||
 	   [[ "$MY_DOWN_COMMAND" = "grep" ]] ||
 	   [[ "$MY_DOWN_COMMAND" = "script" ]] ||
 	   [[ "$MY_DOWN_COMMAND" = "traceroute" ]]; then
@@ -785,6 +815,7 @@ while IFS=';' read -r MY_OK_COMMAND MY_OK_HOSTNAME_STRING MY_OK_PORT || [[ -n "$
 	if [[ "$MY_OK_COMMAND" = "ping" ]] ||
 	   [[ "$MY_OK_COMMAND" = "nc" ]] ||
 	   [[ "$MY_OK_COMMAND" = "curl" ]] ||
+	   [[ "$MY_OK_COMMAND" = "http-status" ]] ||
 	   [[ "$MY_OK_COMMAND" = "grep" ]] ||
 	   [[ "$MY_OK_COMMAND" = "script" ]] ||
 	   [[ "$MY_OK_COMMAND" = "traceroute" ]]; then
@@ -863,6 +894,7 @@ while IFS=';' read -r MY_HISTORY_COMMAND MY_HISTORY_HOSTNAME_STRING MY_HISTORY_P
 	if [[ "$MY_HISTORY_COMMAND" = "ping" ]] ||
 	   [[ "$MY_HISTORY_COMMAND" = "nc" ]] ||
 	   [[ "$MY_HISTORY_COMMAND" = "curl" ]] ||
+	   [[ "$MY_HISTORY_COMMAND" = "http-status" ]] ||
 	   [[ "$MY_HISTORY_COMMAND" = "grep" ]] ||
 	   [[ "$MY_HISTORY_COMMAND" = "script" ]] ||
 	   [[ "$MY_HISTORY_COMMAND" = "traceroute"  ]]; then

--- a/status.sh
+++ b/status.sh
@@ -716,7 +716,7 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		fi
 	elif [[ "$MY_COMMAND" = "http-status" ]]; then
 		(( MY_HOSTNAME_COUNT++))
-		if [[ $(curl -s -o /dev/null -I -w "%{http_code}" "$MY_HOSTNAME" 2>/dev/null) == $MY_PORT ]]; then
+		if [[ $(curl -s -o /dev/null -I --max-time "$MY_TIMEOUT" -w "%{http_code}" "$MY_HOSTNAME" 2>/dev/null) == $MY_PORT ]]; then
 			check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"
 			# Check status change
 			if [[ "$MY_DOWN_TIME" -gt "0" ]]; then

--- a/status_hostname_list.txt
+++ b/status_hostname_list.txt
@@ -4,25 +4,28 @@
 # What should be monitored? Each line one entry.
 #
 # Structure:
-# <COMMAND>;<HOSTNAME, IP or URL,PATH>;<PORT>
+# <COMMAND>;<HOSTNAME, IP or URL,PATH>;<PORT, GREP TEXT or HTTP STATUS>
 #
 # COMMAND: Command to run. Can be ping, curl or nc.
-#          ping       = send ICMP ECHO_REQUEST packets to network hosts
-#          curl       = transfer a URL
-#          nc         = check TCP and UDP connections
-#          grep       = extension to the curl check
-#                       curl downloads the webpage and pipes it to grep,
-#                       that checks if the keyword is in the page.
-#          traceroute = check if host or ip exists in route path to MY_TRACEROUTE_HOST
-#          script     = execute a script which returns 0 on success
+#          ping        = send ICMP ECHO_REQUEST packets to network hosts
+#          curl        = transfer a URL
+#          http-status = check the HTTP status of a URL
+#          nc          = check TCP and UDP connections
+#          grep        = extension to the curl check
+#                        curl downloads the webpage and pipes it to grep,
+#                        that checks if the keyword is in the page.
+#          traceroute  = check if host or ip exists in route path to MY_TRACEROUTE_HOST
+#          script      = execute a script which returns 0 on success
 #
 # HOSTNAME: Hostname for the 'ping', 'nc' or 'traceroute' command
 # IP: IP adress for the 'ping', 'nc' or 'traceroute' command
-# URL: URL called by the command 'curl' and 'grep'. I.e. https://www.heise.de/ping or ftp://ftp.debian.org/debian/README
+# URL: URL called by the command 'curl', 'http-status' and 'grep'. I.e. https://www.heise.de/ping or ftp://ftp.debian.org/debian/README
 # PATH: PATH of the script called by the command 'script', eg. check.sh
 # The pipe `|` can be used as a seperator to display a custom text instead of the HOSTNAME/IP/URL (see example below).
 #
 # PORT: Optional port specification. Only for 'nc' command.
+# GREP TEXT: Text to look for when using the 'grep' command.
+# HTTP STATUS: HTTP status code required to pass when using the 'http-status' command.
 #
 
 #
@@ -42,6 +45,11 @@ nc;www.bsi.de|My secret Hostname;80
 curl;https://www.heise.de/ping
 curl;ftp://ftp.debian.org/debian/README
 curl;https://example.com/|My secret URL
+
+#
+# http-status;<URL>;<STATUS CODE>
+#
+http-status;https://www.heise.de;200
 
 #
 # grep;<URL>;<ONE WORD>


### PR DESCRIPTION
I added a command to check the HTTP status code that gets returned by an URL.

I use it to check the status of one of my sites that is hidden behind HTTP basic authentication. With the authentication enabled the basic curl or grep commands don't work because the site returns HTTP status code 401, which causes curl to exit with a failure. With the new command I can check specifically if 401 is returned, which indicates the site is up.