### PR TITLE
fix: script checks not always working

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -783,7 +783,7 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		else
 			cmd="$MY_HOSTNAME"
 		fi
-		$cmd
+		$cmd &> /dev/null
 		MY_EXIT_CODE=$?
 		if [ $MY_EXIT_CODE -ne 0 ]; then
 			check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"

--- a/status.sh
+++ b/status.sh
@@ -783,16 +783,18 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		else
 			cmd="$MY_HOSTNAME"
 		fi
-		if "$cmd" &> /dev/null; then
+        $cmd
+		exitCode=$?
+		if [ $exitCode -ne 0 ]; then
+			check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"
+			save_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT" "$MY_DOWN_TIME"
+		else
 			check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"
 			# Check status change
 			if [[ "$MY_DOWN_TIME" -gt "0" ]]; then
 				save_history  "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT" "$MY_DOWN_TIME" "$MY_DATE_TIME"
 			fi
 			save_availability "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"
-		else
-			check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"
-			save_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT" "$MY_DOWN_TIME"
 		fi
 	fi
 

--- a/status.sh
+++ b/status.sh
@@ -783,9 +783,9 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		else
 			cmd="$MY_HOSTNAME"
 		fi
-        $cmd
-		exitCode=$?
-		if [ $exitCode -ne 0 ]; then
+		$cmd
+		MY_EXIT_CODE=$?
+		if [ $MY_EXIT_CODE -ne 0 ]; then
 			check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"
 			save_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT" "$MY_DOWN_TIME"
 		else

--- a/status_hostname_list.txt
+++ b/status_hostname_list.txt
@@ -21,7 +21,7 @@
 # IP: IP adress for the 'ping', 'nc' or 'traceroute' command
 # URL: URL called by the command 'curl', 'http-status' and 'grep'. I.e. https://www.heise.de/ping or ftp://ftp.debian.org/debian/README
 # PATH: PATH of the script called by the command 'script', eg. check.sh
-# The pipe `|` can be used as a seperator to display a custom text instead of the HOSTNAME/IP/URL (see example below).
+# The pipe `|` can be used as a separator to display a custom text instead of the HOSTNAME/IP/URL (see example below).
 #
 # PORT: Optional port specification. Only for 'nc' command.
 # GREP TEXT: Text to look for when using the 'grep' command.
@@ -75,4 +75,4 @@ traceroute;your.secret.router|My secret Hostname;2
 # Note: Outage if returncode is not 0
 #
 script;./check.sh|My secret Name
-script;/bin/true|always up
+script;true|always up


### PR DESCRIPTION
- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/static_status/blob/master/CONTRIBUTING.md)
- [x] I used tabs to indent
- [x] I checked my code with [ShellCheck](https://www.shellcheck.net/)

## Notes

I had some problems when setting up all of my tests.

One is simple: the `/bin/true` does not exist on all systems (here Mac) while `true` and `false` worked on several servers I tried. Not sure though which one is more cross-compatible.

The other one is a bit trickier and I might be wrong, as my bash-foo is really far away from being good. But no matter what I tried, all `script` tests failed on my Mac and on my server. I am not sure why, either the way I use it or becuase I appended parameters to the script or because the `if-evaluation` in the code wasn't ideal?

Just for example, I added the following test which failed with your `if` before: 
```
script;mysqladmin ping -h 127.0.0.1 --connect-timeout 2|Database cluster
```
After the change your examples and my added `script` checks worked. 

Here is the raw output of the script check `mysqladmin ping -h 127.0.0.1 --connect-timeout 2` that I use:

<img width="615" alt="Bildschirmfoto 2021-08-12 um 17 25 00" src="https://user-images.githubusercontent.com/533162/129224170-e86a0770-200b-4be6-8bce-ead94dc0975d.png">
The command might be confusing, it shows errors (which can be ignored) but for the check only the exit code is relevant. 

### UPDATE AFTER MORE TESTING
Maybe the entire if change is not necessary, there seems to be a difference between 
```
if $cmd &> /dev/null; then
```
and 
```
if "$cmd" &> /dev/null; then
```
The first one works in my case (error message but exit code 0 leads to operational), while the second one breaks (leads to outage). Do you happen to know the difference?

I could revert most of my changes and only remove the `"`. But before putting any more effort into this, I'd like to get some feedback.