### PR TITLE
Don't do reverse DNS lookups during pings

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -728,16 +728,16 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		(( MY_HOSTNAME_COUNT++ ))
 		# Detect ping Version
 		ping &> /dev/null
-		# FreeBSD: 64 = ping -t TIMEOUT
-		# macOS:   64 = ping -t TIMEOUT
-		# GNU:      2 = ping -w TIMEOUT (-t TTL)
-		# OpenBSD:  1 = ping -w TIMEOUT (-t TTL)
+		# FreeBSD: 64 = ping -n -t TIMEOUT
+		# macOS:   64 = ping -n -t TIMEOUT
+		# GNU:      2 = ping -n -w TIMEOUT (-t TTL)
+		# OpenBSD:  1 = ping -n -w TIMEOUT (-t TTL)
 		if [ $? -gt 2 ]; then
 			# BSD ping
-			MY_PING_COMMAND='ping -t'
+			MY_PING_COMMAND='ping -n -t'
 		else
 			# GNU or OpenBSD ping
-			MY_PING_COMMAND='ping -w'
+			MY_PING_COMMAND='ping -n -w'
 		fi
 		if $MY_PING_COMMAND "$MY_PING_TIMEOUT" -c "$MY_PING_COUNT" "$MY_HOSTNAME" &> /dev/null; then
 			check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" ""


### PR DESCRIPTION
## Please Complete the Following

- [x ] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/static_status/blob/master/CONTRIBUTING.md)
- [x ] I used tabs to indent
- [x ] I checked my code with [ShellCheck](https://www.shellcheck.net/)

## Notes

Ping does reverse dns lookups every time it is sending out an icmp ping request. 
If for some reason the reverse dns lookup takes longer than the ping command deadline option, the ping will be interpreted as failed. (Seen this in practice)
This disables those lookups while still allowing the use of hostnames instead of ip addresses as destinations.