### PR TITLE
enable script parameters for script cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,35 +164,8 @@ Add your script to the `status_hostname_list.txt` configuration file. Example:
 ```
 script;script.sh
 script;/path/to/your/script.sh|Custom Text
-script;/path/to/your/script_a|see symbolic link example
-```
+script;/path/to/your/script.sh parameterA parameterB|Custom Text
 
-Please note that you do not pass any parameters. You can work with symbolic links. Example:
-
-```
-$ ln -sf script.sh script_a
-$ ln -sf script.sh script_b
-$ ls -lah
-script_a -> script.sh
-script_b -> script.sh
-```
-
-Example `script.sh`:
-```
-#!/bin/bash
-
-MY_NAME=$(basename "$0")
-
-case "$MY_NAME" in
-"script_a")
-  echo "A"
-  exit 0
-  ;;
-"script_b")
-  echo "B"
-  exit 0
-  ;;
-esac
 ```
 
 ## TODO

--- a/status.sh
+++ b/status.sh
@@ -918,7 +918,7 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		else
 			cmd="$MY_HOSTNAME"
 		fi
-		$cmd > /dev/null
+		($cmd &> /dev/null)
 		case "$?" in
 			"0")
 				check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"

--- a/status.sh
+++ b/status.sh
@@ -823,7 +823,7 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		else
 			cmd="$MY_HOSTNAME"
 		fi
-		if "$cmd" &> /dev/null; then
+		if $cmd &> /dev/null; then
 			check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"
 			# Check status change
 			if [[ "$MY_DOWN_TIME" -gt "0" ]]; then


### PR DESCRIPTION
## Please Complete the Following

- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/static_status/blob/master/CONTRIBUTING.md)
- [x] I used tabs to indent
- [x] I checked my code with [ShellCheck](https://www.shellcheck.net/)


## Removing the Quotes to enable parameters.

I am not quite sure if there is deeper reasoning behind making the $cmd atomic, as there is a whole section in the README.md about it. At least there was nothing mentioned in https://github.com/Cyclenerd/static_status/pull/17 .

Removing the Quotes enables parameters for my usecase and seems not to break anything. (I have a script checking ssl cert end dates and do not wand to create a symlink for each host I am checking).

### example
After my change the following config 
```
script;ls /home|home
script;ls /notexisting|not here
```
leads to this status.json:
```
% cat ~/status.json
[
  {
    "site": "not here",
    "command": "script",
    "status": "Fail",
    "updated": "2021-12-08 16:44:28 UTC"
  },
  {
    "site": "home",
    "command": "script",
    "status": "OK",
    "updated": "2021-12-08 16:44:28 UTC"
  }
]
```
