### PR TITLE
Add var to set minimum of minutes downtime to shown in past incidents

### DIFF
--- a/config-example
+++ b/config-example
@@ -57,8 +57,8 @@ MY_HOSTNAME_STATUS_LASTRUN="$MY_STATUS_CONFIG_DIR/status_hostname_last.txt"
 MY_HOSTNAME_STATUS_HISTORY="$MY_STATUS_CONFIG_DIR/status_hostname_history.txt"
 MY_HOSTNAME_STATUS_HISTORY_TEMP_SORT="/tmp/status_hostname_history_sort.txt"
 
-# Minimum downtime in minutes to display in past incidents
-MY_MIN_DOWN_TIME="1"
+# Minimum downtime in seconds to display in past incidents
+MY_MIN_DOWN_TIME="60"
 
 # CSS Stylesheet for the status page
 MY_STATUS_STYLESHEET="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/css/bootstrap.min.css"

--- a/config-example
+++ b/config-example
@@ -57,6 +57,9 @@ MY_HOSTNAME_STATUS_LASTRUN="$MY_STATUS_CONFIG_DIR/status_hostname_last.txt"
 MY_HOSTNAME_STATUS_HISTORY="$MY_STATUS_CONFIG_DIR/status_hostname_history.txt"
 MY_HOSTNAME_STATUS_HISTORY_TEMP_SORT="/tmp/status_hostname_history_sort.txt"
 
+# Minimum downtime in minutes to display in past incidents
+MY_MIN_DOWN_TIME="1"
+
 # CSS Stylesheet for the status page
 MY_STATUS_STYLESHEET="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/css/bootstrap.min.css"
 

--- a/status.sh
+++ b/status.sh
@@ -71,8 +71,8 @@ MY_HOSTNAME_STATUS_LASTRUN="$MY_STATUS_CONFIG_DIR/status_hostname_last.txt"
 MY_HOSTNAME_STATUS_HISTORY="$MY_STATUS_CONFIG_DIR/status_hostname_history.txt"
 MY_HOSTNAME_STATUS_HISTORY_TEMP_SORT="/tmp/status_hostname_history_sort.txt"
 
-# Minimum downtime in minutes to display in past incidents
-MY_MIN_DOWN_TIME="1"
+# Minimum downtime in seconds to display in past incidents
+MY_MIN_DOWN_TIME="60"
 
 # CSS Stylesheet for the status page
 MY_STATUS_STYLESHEET="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.5.3/css/bootstrap.min.css"
@@ -970,7 +970,7 @@ MY_HISTORY_ITEMS=()
 MY_SHOW_INCIDENTS="false"
 while IFS=';' read -r MY_HISTORY_COMMAND MY_HISTORY_HOSTNAME_STRING MY_HISTORY_PORT MY_HISTORY_DOWN_TIME MY_HISTORY_DATE_TIME || [[ -n "$MY_HISTORY_COMMAND" ]]; do
 
-	if [[ "$((MY_HISTORY_DOWN_TIME/60))" -gt "$MY_MIN_DOWN_TIME" ]]; then
+	if [[ "$MY_HISTORY_DOWN_TIME" -ge "$MY_MIN_DOWN_TIME" ]]; then
 		
 		MY_SHOW_INCIDENTS="true"
 


### PR DESCRIPTION
- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/static_status/blob/master/CONTRIBUTING.md)
- [x] I used tabs to indent
- [x] I checked my code with [ShellCheck](https://www.shellcheck.net/)

## Notes

Sometimes I have a somehow "flaky" internet connection. I don't want every single minute of failed status test listed in **Past incidents**. Lets configure how many minutes of downtime are worth mentioning in **Past incidents**.