### PR TITLE
fix(ping): FreeBSD ping version detection failed

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -804,7 +804,7 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		# macOS:   64 = ping -n -t TIMEOUT
 		# GNU:      2 = ping -n -w TIMEOUT (-t TTL)
 		# OpenBSD:  1 = ping -n -w TIMEOUT (-t TTL)
-		if [ $? -gt 2 ] || [ $OS_ID = "freebsd" ]; then
+		if [ $? -gt 2 ] || [ "$OS_ID" = "freebsd" ]; then
 			# BSD ping
 			MY_PING_COMMAND='ping -n -t'
 		else
@@ -829,7 +829,7 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		# macOS:   64 = ping6 -n -t TIMEOUT
 		# GNU:      2 = ping6 -n -w TIMEOUT (-t TTL)
 		# OpenBSD:  1 = ping6 -n -w TIMEOUT (-t TTL)
-		if [ $? -gt 2 ] || [ $OS_ID = "freebsd" ]; then
+		if [ $? -gt 2 ] || [ "$OS_ID" = "freebsd" ]; then
 			# BSD ping6
 			MY_PING6_COMMAND='ping6 -n -t'
 		else

--- a/status.sh
+++ b/status.sh
@@ -111,6 +111,7 @@ MY_TIMESTAMP=$(date -u "+%s")
 MY_LASTRUN_TIME="0"
 BE_LOUD="no"
 BE_QUIET="no"
+OS_ID=$(awk -F= '$1=="ID" { print $2 ;}' /etc/os-release) # Source: https://unix.stackexchange.com/a/432819 - Author: Archemar
 
 # if a config file has been specified with MY_STATUS_CONFIG=myfile use this one, otherwise default to config
 if [[ -z "$MY_STATUS_CONFIG" ]]; then
@@ -800,11 +801,10 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		(( MY_HOSTNAME_COUNT++ ))
 		# Detect ping Version
 		ping &> /dev/null
-		# FreeBSD: 64 = ping -n -t TIMEOUT
 		# macOS:   64 = ping -n -t TIMEOUT
 		# GNU:      2 = ping -n -w TIMEOUT (-t TTL)
 		# OpenBSD:  1 = ping -n -w TIMEOUT (-t TTL)
-		if [ $? -gt 2 ]; then
+		if [ $? -gt 2 ] || [ $OS_ID = "freebsd" ]; then
 			# BSD ping
 			MY_PING_COMMAND='ping -n -t'
 		else
@@ -826,11 +826,10 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		(( MY_HOSTNAME_COUNT++ ))
 		# Detect ping6 Version
 		ping6 &> /dev/null
-		# FreeBSD: 64 = ping6 -n -t TIMEOUT
 		# macOS:   64 = ping6 -n -t TIMEOUT
 		# GNU:      2 = ping6 -n -w TIMEOUT (-t TTL)
 		# OpenBSD:  1 = ping6 -n -w TIMEOUT (-t TTL)
-		if [ $? -gt 2 ]; then
+		if [ $? -gt 2 ] || [ $OS_ID = "freebsd" ]; then
 			# BSD ping6
 			MY_PING6_COMMAND='ping6 -n -t'
 		else

--- a/status.sh
+++ b/status.sh
@@ -111,7 +111,6 @@ MY_TIMESTAMP=$(date -u "+%s")
 MY_LASTRUN_TIME="0"
 BE_LOUD="no"
 BE_QUIET="no"
-OS_ID=$(awk -F= '$1=="ID" { print $2 ;}' /etc/os-release) # Source: https://unix.stackexchange.com/a/432819 - Author: Archemar
 
 # if a config file has been specified with MY_STATUS_CONFIG=myfile use this one, otherwise default to config
 if [[ -z "$MY_STATUS_CONFIG" ]]; then
@@ -804,7 +803,7 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		# macOS:   64 = ping -n -t TIMEOUT
 		# GNU:      2 = ping -n -w TIMEOUT (-t TTL)
 		# OpenBSD:  1 = ping -n -w TIMEOUT (-t TTL)
-		if [ $? -gt 2 ] || [ "$OS_ID" = "freebsd" ]; then
+		if [ $? -gt 2 ] || [[ "$OSTYPE" == "freebsd"* ]]; then
 			# BSD ping
 			MY_PING_COMMAND='ping -n -t'
 		else
@@ -829,7 +828,7 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		# macOS:   64 = ping6 -n -t TIMEOUT
 		# GNU:      2 = ping6 -n -w TIMEOUT (-t TTL)
 		# OpenBSD:  1 = ping6 -n -w TIMEOUT (-t TTL)
-		if [ $? -gt 2 ] || [ "$OS_ID" = "freebsd" ]; then
+		if [ $? -gt 2 ] || [[ "$OSTYPE" == "freebsd"* ]]; then
 			# BSD ping6
 			MY_PING6_COMMAND='ping6 -n -t'
 		else


### PR DESCRIPTION
Use ID from /etc/os-release to identify ping command required for FreeBSD
Necessary due to same return code as OpenBSD (1), at least, in FreeBSD 13

First off, thanks for taking the time to contribute!

## Please Complete the Following

- [X] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/static_status/blob/master/CONTRIBUTING.md)
- [X] I used tabs to indent
- [X] I checked my code with [ShellCheck](https://www.shellcheck.net/)

## Notes

I'm running static_status on FreeBSD 13 and the detection of the ping command failed.
A number higher 2 is expected as return code of `ping &> /dev/null`, but it's always `1`.
Usage of the ID from `/etc/os-release` instead the rc of the ping command solved the issue.
Tested with version 13 but should behave similar on earlier versions as well.