### PR TITLE
Fix and enhance "degraded" status

### DIFF
--- a/config-example
+++ b/config-example
@@ -53,8 +53,9 @@ MY_TRACEROUTE_NQUERIES="1"
 # Location for the status files. Please do not edit created files.
 MY_HOSTNAME_STATUS_OK="$MY_STATUS_CONFIG_DIR/status_hostname_ok.txt"
 MY_HOSTNAME_STATUS_DOWN="$MY_STATUS_CONFIG_DIR/status_hostname_down.txt"
-MY_HOSTNAME_STATUS_DEGRADE="$MY_STATUS_CONFIG_DIR/status_hostname_degrade.txt"
 MY_HOSTNAME_STATUS_LASTRUN="$MY_STATUS_CONFIG_DIR/status_hostname_last.txt"
+MY_HOSTNAME_STATUS_DEGRADE="$MY_STATUS_CONFIG_DIR/status_hostname_degrade.txt"
+MY_HOSTNAME_STATUS_LASTRUN_DEGRADE="$MY_STATUS_CONFIG_DIR/status_hostname_last_degrade.txt"
 MY_HOSTNAME_STATUS_HISTORY="$MY_STATUS_CONFIG_DIR/status_hostname_history.txt"
 MY_HOSTNAME_STATUS_HISTORY_TEMP_SORT="/tmp/status_hostname_history_sort.txt"
 


### PR DESCRIPTION
- [X] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/static_status/blob/master/CONTRIBUTING.md)
- [X] I used tabs to indent
- [X] I checked my code with [ShellCheck](https://www.shellcheck.net/)

## Notes

`status.sh`:
- Added MY_HOSTNAME_STATUS_DEGRADE for "degraded" services
- Added MY_HOSTNAME_STATUS_LASTRUN_DEGRADE for calculating "degraded" time of services
- Fixed naming of MY_DEGRADE_COUNT (was MY_OUTAGEDEGRADE_COUNT)
- Fixed some typos
    
`alert.sh`:
- Added MY_HOSTNAME_STATUS_DEGRADE for "degraded" services
- Added logic for services which are first "degraded" and then are changing to "down"
- Simplifed logic for adding entries to MY_HOSTNAME_STATUS and MY_HOSTNAME_STATUS_DEGRADE (only write or delete them once, not on every notification)
    
`config-example`:
- Added MY_HOSTNAME_STATUS_DEGRADE parameter for file with "degraded" services
