### PR TITLE
Keep error code with timeout (--preserve-status)

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -915,7 +915,7 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		else
 			cmd="$MY_HOSTNAME"
 		fi
-		(timeout "$MY_SCRIPT_TIMEOUT" "$cmd" &> /dev/null)
+		(timeout "$MY_SCRIPT_TIMEOUT" --preserve-status "$cmd" &> /dev/null)
 		case "$?" in
 			"0")
 				check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"


### PR DESCRIPTION
## Please Complete the Following

- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/static_status/blob/master/CONTRIBUTING.md)
- [x] I used tabs to indent
- [x] I checked my code with [ShellCheck](https://www.shellcheck.net/)

## Notes

Fix for my last PR https://github.com/Cyclenerd/static_status/pull/79. Keep error code of actual script command, not the one from `timeout`, added `--preserve-status`.