### PR TITLE
Small fix: --preserve-status has to be before timeout number

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -915,7 +915,7 @@ while IFS=';' read -r MY_COMMAND MY_HOSTNAME_STRING MY_PORT || [[ -n "$MY_COMMAN
 		else
 			cmd="$MY_HOSTNAME"
 		fi
-		(timeout "$MY_SCRIPT_TIMEOUT" --preserve-status "$cmd" &> /dev/null)
+		(timeout --preserve-status "$MY_SCRIPT_TIMEOUT" "$cmd" &> /dev/null)
 		case "$?" in
 			"0")
 				check_downtime "$MY_COMMAND" "$MY_HOSTNAME_STRING" "$MY_PORT"


### PR DESCRIPTION
- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/static_status/blob/master/CONTRIBUTING.md)
- [x] I used tabs to indent
- [x] I checked my code with [ShellCheck](https://www.shellcheck.net/)

## Notes
I'm sorry, here is another fix for https://github.com/Cyclenerd/static_status/pull/79. I had it like this in my environment but unfortunately I pushed https://github.com/Cyclenerd/static_status/pull/80 with the wrong order.